### PR TITLE
ci: pin GitHub Actions to SHA digests (fix zizmor unpinned-uses)

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -26,10 +26,10 @@ jobs:
           echo "DATE_TAG=$(TZ='America/Seattle' date +'%Y.%m.%d')" >> "$GITHUB_ENV"
 
       - name: Checkout files in repo
-        uses: actions/checkout@main
+        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # main
 
       - name: Build and push the image to quay.io ${{ matrix.environment }}
-        uses: jupyterhub/repo2docker-action@master
+        uses: jupyterhub/repo2docker-action@92fefcbd2b46dd9716f5263a9e740cbc972f6dd9 # master
         with:
           # Make sure username & password/token pair matches your registry credentials
           DOCKER_USERNAME: ${{ secrets.QUAY_USERNAME }}

--- a/.github/workflows/quarto-publish.yaml
+++ b/.github/workflows/quarto-publish.yaml
@@ -16,13 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Quarto
-        uses: quarto-dev/quarto-actions/setup@v2
+        uses: quarto-dev/quarto-actions/setup@8a96df13519ee81fd526f2dfca5962811136661b # v2
 
       - name: Publish to GitHub Pages (and render)
-        uses: quarto-dev/quarto-actions/publish@v2
+        uses: quarto-dev/quarto-actions/publish@8a96df13519ee81fd526f2dfca5962811136661b # v2
         with:
           target: gh-pages
         env:


### PR DESCRIPTION
Pins all GitHub Actions workflow steps to full SHA digests, eliminating the `unpinned-uses` supply-chain risk identified by zizmor (5 findings fixed).

Closes #31

### Recommended next steps

1. Enable Dependabot for `github-actions` to keep pinned SHAs up-to-date automatically (a companion PR may be opened for this repo).
2. Add [zizmor-action](https://github.com/zizmorcore/zizmor-action?tab=readme-ov-file#usage-with-github-advanced-security-recommended) for continuous workflow security scanning in CI.

---
_Generated by [ds-security-scanning](https://github.com/developmentseed/ds-security-scanning) zizmor-cli-unpinned-uses_